### PR TITLE
[Bug] 将后端opencv-python固定到与PaddleRS一致，避免出现不兼容

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ marshmallow>=3.18.0
 marshmallow_sqlalchemy>=0.28.1
 matplotlib>=3.5.3
 numpy>=1.23.3
-opencv_python>=4.5.1.48,<=4.5.5.64
+opencv-python==4.3.0.38
 Pillow>=9.2.0
 PyMySQL>=1.0.2
 python-dotenv>=0.21.0


### PR DESCRIPTION
由于PaddleRS中要求opencv-contrib-python == 4.3.0.38，原requirements.txt中要求opencv_python>=4.5.1.48,<=4.5.5.64，在实际测试中发现会导致与PaddleRS所需依赖冲突，故将后端opencv-python固定到与PaddleRS一致，避免出现不兼容。