### PR TITLE
[Docs] 更新教程中百度地图Access Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ pip install -r PaddleRS/requirements.txt
 pip install -e PaddleRS/
 ```
 
+### 百度地图Access Key的设置
+在根目录下的`config.yaml`文件中，按以下规则替换百度地图的Access Key。百度地图的Access Key可在[百度地图开放平台](http://lbsyun.baidu.com/apiconsole/key?application=key)申请。
+``` yaml
+baidu_map:
+  access_key: {百度地图ACCESS_KEY}
+```
+
 ### Web后端的安装
 
 #### 安装依赖

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -64,6 +64,13 @@ MYSQL_USERNAME={MySQL用户名}
 MYSQL_PASSWORD={MySQL用户密码}
 ```
 
+### 设置百度地图Access Key
+在根目录下的`config.yaml`文件中，按以下规则替换百度地图的Access Key。百度地图的Access Key可在[百度地图开放平台](http://lbsyun.baidu.com/apiconsole/key?application=key)申请。
+``` yaml
+baidu_map:
+  access_key: {百度地图ACCESS_KEY}
+```
+
 ### （可选）修改IP地址和端口号
 
 若您需要指定前端、后端的IP地址或端口号，请按以下规则编辑项目根目录下的`config.yaml`文件：


### PR DESCRIPTION
1. 由于百度地图Access Key需要用户自行申请并设置，因此添加相关教程。